### PR TITLE
#2 오류 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'java'
 sourceCompatibility = 1.8
 compileJava.options.encoding = 'UTF-8'
 
-version = '6.2.3.0'
+version = '6.4.0.0'
 jar {
     manifest {
         attributes 'Implementation-Title': 'Elasticsearch Jaso Analyzer Plugin',
@@ -17,7 +17,7 @@ repositories {
 
 dependencies {
     compile group: 'commons-collections', name: 'commons-collections', version: '3.2'
-    compile 'org.elasticsearch:elasticsearch:6.2.3'
+    compile 'org.elasticsearch:elasticsearch:6.4.0'
     compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.11.0'
     compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.11.0'
     testCompile group: 'junit', name: 'junit', version: '4.+'
@@ -37,12 +37,10 @@ uploadArchives {
 }
 
 task buildPluginZip(type: Zip, dependsOn:[':jar']) {
-    into('elasticsearch') {
-        baseName = 'jaso-analyzer-plugin'
-        classifier = 'plugin'
-        from files(libsDir)
-        from 'src/main/resources'
-    }
+    baseName = 'jaso-analyzer-plugin'
+    classifier = 'plugin'
+    from files(libsDir)
+    from 'src/main/resources'
 }
 
 artifacts {

--- a/src/main/resources/plugin-descriptor.properties
+++ b/src/main/resources/plugin-descriptor.properties
@@ -1,6 +1,6 @@
 description=Jaso Korean Text Analyzer
-version=6.2.3.0
+version=6.4.0.0
 name=jaso-analyzer
 classname=org.elasticsearch.plugin.analysis.JasoAnalysisPlugin
 java.version=1.8
-elasticsearch.version=6.2.3
+elasticsearch.version=6.4.0


### PR DESCRIPTION
This plugin was built with an older plugin structure. Contact the plugin author to remove the intermediate "elasticsearch" directory within the plugin zip. 오류를 수정하고
elasticsearch 버전을 6.4.0 으로 변경하였습니다.